### PR TITLE
Go fix

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -4,9 +4,9 @@ import (
 	"flag"
 	"io/fs"
 	"os"
-	"testing/fstest"
 	"path/filepath"
 	"testing"
+	"testing/fstest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,8 +15,6 @@ import (
 )
 
 var update = flag.Bool("update", false, "update golden files")
-
-func boolPtr(v bool) *bool { return &v }
 
 // minimalConfig returns a resolved config with a single module and all output enabled.
 func minimalConfig() *config.Config {
@@ -41,7 +39,7 @@ func minimalConfig() *config.Config {
 				Name:     "foo",
 				Repo:     "https://github.com/example/foo",
 				Branch:   "main",
-				GoSource: boolPtr(true),
+				GoSource: new(true),
 				Redirect: "https://pkg.go.dev/go.example.com/foo",
 			},
 		},
@@ -79,7 +77,7 @@ func TestGenerate_SingleModule(t *testing.T) {
 func TestGenerate_GoSourceDisabled(t *testing.T) {
 	cfg := minimalConfig()
 	cfg.Output.Dir = filepath.Join(t.TempDir(), "dist")
-	cfg.Modules[0].GoSource = boolPtr(false)
+	cfg.Modules[0].GoSource = new(false)
 
 	gen, err := New()
 	require.NoError(t, err)
@@ -134,7 +132,7 @@ func TestGenerate_MultipleModules(t *testing.T) {
 		Name:     "bar",
 		Repo:     "https://github.com/example/bar",
 		Branch:   "develop",
-		GoSource: boolPtr(true),
+		GoSource: new(true),
 		Redirect: "https://pkg.go.dev/go.example.com/bar",
 	})
 

--- a/internal/server/logger.go
+++ b/internal/server/logger.go
@@ -26,7 +26,7 @@ type slogEntry struct {
 	from   string
 }
 
-func (e *slogEntry) Write(status, bytes int, header http.Header, elapsed time.Duration, _ interface{}) {
+func (e *slogEntry) Write(status, bytes int, _ http.Header, elapsed time.Duration, _ any) {
 	slog.Info("request",
 		"method", e.method,
 		"path", e.path,
@@ -37,7 +37,7 @@ func (e *slogEntry) Write(status, bytes int, header http.Header, elapsed time.Du
 	)
 }
 
-func (e *slogEntry) Panic(v interface{}, stack []byte) {
+func (e *slogEntry) Panic(v any, stack []byte) {
 	slog.Error("request panic",
 		"method", e.method,
 		"path", e.path,


### PR DESCRIPTION
Ran the `go fix ./...` command new with Go 1.26 for minor cleanups of deprecated styles of coding.